### PR TITLE
Add Security Dependency to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+    	<groupId>org.springframework.boot</groupId>
+    	<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-spatial</artifactId>


### PR DESCRIPTION
Add JWT Security Dependency to pom.xml file.
Default security behaviour will be applied.
All endpoints will be locked with auth by default username and generated password.